### PR TITLE
fix reading time & last updated for splash

### DIFF
--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -6,10 +6,24 @@ import getReadingTime from "reading-time";
 
 const readingTime = getReadingTime(Astro.props.entry.body)
 
+let lastUpdated: Date | undefined;
+if (typeof Astro.props.entry.data.lastUpdated === 'number') {
+    lastUpdated = new Date(Astro.props.entry.data.lastUpdated)
+} else if (Astro.props.entry.data.lastUpdated instanceof Date) {
+    lastUpdated = Astro.props.entry.data.lastUpdated
+}
+
+const lastUpdatedString = lastUpdated?.toLocaleDateString('en-US', { year: "numeric", month: "long", day: "numeric" })
+
 // TODO: add created at time
 ---
 
 <Default {...Astro.props}></Default>
 
-<p>{readingTime.text} • Last updated {new Date(Astro.props.entry.data.lastUpdated).toLocaleDateString('en-US', { year: "numeric", month: "long", day: "numeric" })}</p>
+{
+    // Only display the reading time & last updated when it is a doc
+    Astro.props.entry.data.template === 'doc'
+        ? <p>{readingTime.text}{lastUpdatedString ? ` • Last updated ${lastUpdatedString}` : ''}</p>
+        : null
+}
 


### PR DESCRIPTION
Before | After
-|-
<img width="636" alt="image" src="https://github.com/user-attachments/assets/89ea1abf-084e-40ce-94db-c5c9a2e5b582" />  |<img width="637" alt="image" src="https://github.com/user-attachments/assets/733c3b20-5d86-4562-ab1c-ace2d93a56e4" />
<img width="351" alt="image" src="https://github.com/user-attachments/assets/739a5fc8-cc2d-4432-a36e-f891c22220d8" /> | <img width="474" alt="image" src="https://github.com/user-attachments/assets/1c126afa-4e8b-4be3-a59f-ce4d0ce5237a" />

