### PR TITLE
remove all TOCs

### DIFF
--- a/src/content/docs/posts/Dark mode/light-dark-mode-react-implementation.mdx
+++ b/src/content/docs/posts/Dark mode/light-dark-mode-react-implementation.mdx
@@ -22,31 +22,6 @@ In the previous posts, we saw how to:
 In this post, we'll see how we can use everything together, and add **React** and a remote database (for fun) in this mix.
 The goal is to show the backbone of what could be the actual code you'd use to handle themes in your app.
 
-## Table of contents
-
-1. [Introduction](#introduction)
-2. [Table of contents](#table-of-contents)
-3. [Flow of the logic we'll implement](#flow-of-the-logic-well-implement)
-   1. [First visit ever](#first-visit-ever)
-   2. [First visit on a new browser](#first-visit-on-a-new-browser)
-   3. [Re-visit](#re-visit)
-4. [Results](#results)
-5. [Explanations](#explanations)
-   1. [HTML](#html)
-      1. [CSS](#css)
-      2. [Blocking script](#blocking-script)
-   2. [JavaScript](#javascript)
-      1. [Base variables](#base-variables)
-      2. [React context](#react-context)
-      3. [Initialization of the mode](#initialization-of-the-mode)
-      4. [Database sync](#database-sync)
-      5. [Save back the mode](#save-back-the-mode)
-      6. [Initialization of the mode](#initialization-of-the-mode-1)
-      7. [System theme update](#system-theme-update)
-      8. [Apply the theme back to the HTML](#apply-the-theme-back-to-the-html)
-      9. [Defining the context](#defining-the-context)
-6. [Conclusion](#conclusion)
-
 ## Flow of the logic we'll implement
 
 The following flow is related to a frontend app, not a server-side rendered website (like what you would have in PHP):

--- a/src/content/docs/posts/Others/intlsegmenter-dont-use-stringsplit-nor-stringlength.mdx
+++ b/src/content/docs/posts/Others/intlsegmenter-dont-use-stringsplit-nor-stringlength.mdx
@@ -7,16 +7,6 @@ image: /src/assets/excalidraw/intl-splash-image.png
 description: "UTF is tricky: the length of a string can mean a lot of different things based on whether you want the number of code points, code units, and graphemes. What are the differences, and how can we navigate through those using JavaScript?"
 ---
 
-1. [TL;DR](#tldr)
-2. [Explanation](#explanation)
-   1. [Definitions](#definitions)
-   2. [UTF-16](#utf-16)
-   3. [String.prototype.length](#stringprototypelength)
-   4. [Unicode composition](#unicode-composition)
-   5. [Emoji Sequence](#emoji-sequence)
-3. [Intl.Segmenter](#intlsegmenter)
-   1. [Browser compatibility](#browser-compatibility)
-
 The other day I was playing with JS and I saw this:
 
 ```js

--- a/src/content/docs/posts/Yarn/yarn-lock-how-to-update-it.mdx
+++ b/src/content/docs/posts/Yarn/yarn-lock-how-to-update-it.mdx
@@ -21,17 +21,6 @@ So, if you really care about your app, you should be able to read this lock file
 
 If you spot something weird in the lockfile, this article will tell you how to fix it.
 
-1. [Problem](#problem)
-2. [Solutions](#solutions)
-   1. [Manually editing the lock file](#manually-editing-the-lock-file)
-   2. [The `resolutions` field](#the-resolutions-field)
-   3. [Removing the `yarn.lock` file](#removing-the-yarnlock-file)
-   4. [`yarn dedupe` (recommended)](#yarn-dedupe-recommended)
-3. [Bonus: listing all versions of a package](#bonus-listing-all-versions-of-a-package)
-   1. [Yarn 1](#yarn-1)
-   2. [Yarn 2+](#yarn-2)
-4. [Conclusion](#conclusion)
-
 ## Problem
 
 Note: I'll use the semver syntax, more information on it here: https://jubianchi.github.io/semver-check/.


### PR DESCRIPTION
Having the TOCs in the body of the articles is weird as we have them also in the sidebar (even on mobile)

Before | After
-|-
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f67f78bb-2a4f-46d9-8b1a-a8b349c687b2" /> | <img width="1440" alt="image" src="https://github.com/user-attachments/assets/61b2d0b0-d701-408d-baeb-f11a12ce4abf" />

