### PR TITLE
remove LinkToPost from pagefind

### DIFF
--- a/src/components/LinkToPost.astro
+++ b/src/components/LinkToPost.astro
@@ -42,4 +42,6 @@ if (description) {
 }
 ---
 
-<LinkCard {...props} />
+<div data-pagefind-ignore>
+  <LinkCard {...props} />
+</div>


### PR DESCRIPTION

Input | Before | After
-|-|-
<img width="788" alt="Screenshot 2025-01-04 at 12 19 43" src="https://github.com/user-attachments/assets/7af9406e-e405-479b-b439-902cfa107e20" /> | <img width="623" alt="Screenshot 2025-01-04 at 12 19 59" src="https://github.com/user-attachments/assets/362f2db6-0176-4fdc-8586-296d8d1c40f8" /> | <img width="651" alt="image" src="https://github.com/user-attachments/assets/006254af-411c-4823-9f84-6ccbfae0cd86" />
<img width="817" alt="Screenshot 2025-01-04 at 12 20 40" src="https://github.com/user-attachments/assets/6fba215e-2324-4b8d-9d08-9989e6135cc4" /> |<img width="668" alt="Screenshot 2025-01-04 at 12 20 33" src="https://github.com/user-attachments/assets/edcd7ec8-4854-4156-91d9-75c6349dbb8c" /> | <img width="662" alt="image" src="https://github.com/user-attachments/assets/32b3d572-80d2-47b8-b8d6-eac5eab0c792" />


