### PR TITLE
Remove mapped type

### DIFF
--- a/src/components/experiments/page-react-extension/stack/CustomPragma.tsx
+++ b/src/components/experiments/page-react-extension/stack/CustomPragma.tsx
@@ -20,7 +20,7 @@ class Foo extends React.Component {
     );
     console.trace();
     // console.log("Class current fiber:", this._reactInternals);
-    return h(Bar);
+    return h("div", null, h(Bar), h(Paz));
   }
 }
 setName(Foo, "Foo");

--- a/src/components/experiments/page-react-extension/stack/click-listener.ts
+++ b/src/components/experiments/page-react-extension/stack/click-listener.ts
@@ -12,35 +12,20 @@ export const startClickListening = () => {
     const formattedErrorStack = [];
     let current: Fiber | null = fiber;
     while (current) {
-      // @ts-expect-error
-      const foundStackViaType = window._DEBUG_MAPPED_TYPES.get(
-        current.elementType,
-      );
-
+      console.log("current.pendingProps", current.pendingProps);
+      if (!current.pendingProps) {
+        console.log(current);
+      }
       // @ts-expect-error
       const foundStackViaProps = window._DEBUG_MAPPED_PROPS.get(
         current.pendingProps,
       );
 
-      if (
-        foundStackViaProps &&
-        foundStackViaType &&
-        foundStackViaProps !== foundStackViaType
-      ) {
-        console.error("[CUSTOM] CONFLICT", {
-          current,
-          foundStackViaType,
-          foundStackViaProps,
-        });
-      }
-      const foundStack = foundStackViaProps || foundStackViaType;
-
-      if (foundStack) {
-        formattedErrorStack.push(formatStack(foundStack));
+      if (foundStackViaProps) {
+        formattedErrorStack.push(formatStack(foundStackViaProps));
       } else {
         console.warn(
-          "[CUSTOM] No stack for",
-          current.elementType?.name,
+          `[CUSTOM] No stack for "${current.elementType?.name}"`,
           current,
         );
       }


### PR DESCRIPTION
We don't need the type matcher as the props one always works (except for the root one):

Props are always at least `{}` (and new for every `ReactElement`):

<img width="337" alt="image" src="https://github.com/user-attachments/assets/273dbd5a-f94a-49ae-8c5c-b73a70c0fe46" />
