### PR TITLE
reading-time: account for images, code blocks, and JSX

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
 
 import remarkBreaks from "remark-breaks";
+import { remarkReadingTime } from "./tools/remark-reading-time.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -19,7 +20,7 @@ export default defineConfig({
   },
 
   markdown: {
-    remarkPlugins: [remarkBreaks],
+    remarkPlugins: [remarkBreaks, remarkReadingTime],
   },
 
   integrations: [

--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
     "@types/react-dom": "^19.0.4",
     "@types/reveal.js": "^5.0.5",
     "astro": "^5.5.5",
+    "mdast-util-to-string": "^4.0.0",
     "prettier": "^3.5.3",
     "prettier-plugin-astro": "^0.14.1",
     "reading-time": "^1.5.0",
     "remark-breaks": "^4.0.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "unist-util-filter": "^5.0.1"
   }
 }

--- a/src/components/experiments/page-react-extension/extension.ts
+++ b/src/components/experiments/page-react-extension/extension.ts
@@ -90,7 +90,7 @@
 import { instrument, traverseRenderedFibers } from "bippy"; // must be imported BEFORE react
 
 instrument({
-  onCommitFiberRoot(rendererID, root) {
+  onCommitFiberRoot(_rendererID, root) {
     // console.log("root ready to commit", rendererID, root);
     traverseRenderedFibers(root, (fiber) => {
       console.log("fiber rendered", fiber);

--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -1,11 +1,14 @@
 ---
-import Default from "@astrojs/starlight/components/PageTitle.astro";
+import { render } from "astro:content";
 
-import getReadingTime from "reading-time";
+import Default from "@astrojs/starlight/components/PageTitle.astro";
 
 import { getCreatedDate } from "@components/get-posts";
 
-const readingTime = getReadingTime(Astro.locals.starlightRoute.entry.body);
+const { remarkPluginFrontmatter } = await render(
+  // @ts-expect-error – this works, but for some reasons, it doesn’t seem to be compatible at the type level
+  Astro.locals.starlightRoute.entry,
+);
 
 const createdDate = getCreatedDate(Astro.locals.starlightRoute.entry);
 ---
@@ -16,7 +19,7 @@ const createdDate = getCreatedDate(Astro.locals.starlightRoute.entry);
   // Only display the reading time & last updated when it is a doc
   Astro.locals.starlightRoute.entry.data.template === "doc" ? (
     <p>
-      {readingTime.text}
+      {remarkPluginFrontmatter.readingTime.displayedText}
       {createdDate ? ` • ${createdDate}` : ""}
     </p>
   ) : null

--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -43,6 +43,7 @@ export function remarkReadingTime() {
         nbOfImages++;
       }
       return (
+        // Food for thoughts: treat `code` as images 🤔
         node.type !== "code" && // Remove code blocks (easily read)
         node.type !== "mdxJsxFlowElement" && // Remove component rendered (like <Hello />)
         node.type !== "mdxjsEsm" // Remove imports

--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -1,0 +1,89 @@
+import getReadingTime from "reading-time";
+import { toString } from "mdast-util-to-string";
+import { filter } from "unist-util-filter";
+
+import assert from "node:assert/strict";
+
+const WORDS_PER_MINUTE = 265;
+
+const getSecondsAddedByImages = (imageCount) => {
+  const nbOfImagesBellow10 = Math.max(Math.min(imageCount, 10), 0);
+  const secondsAddedByImagesBellow10 =
+    12 * nbOfImagesBellow10 -
+    (nbOfImagesBellow10 * (nbOfImagesBellow10 - 1)) / 2;
+
+  const nbOfImagesAbove10 = Math.max(imageCount - 10, 0);
+  const secondsAddedByImagesAbove10 = nbOfImagesAbove10 * 3;
+
+  return secondsAddedByImagesBellow10 + secondsAddedByImagesAbove10;
+};
+let totalForTest = 0;
+assert.equal(getSecondsAddedByImages(-1), (totalForTest += 0));
+assert.equal(getSecondsAddedByImages(0), (totalForTest += 0));
+assert.equal(getSecondsAddedByImages(1), (totalForTest += 12));
+assert.equal(getSecondsAddedByImages(2), (totalForTest += 11));
+assert.equal(getSecondsAddedByImages(3), (totalForTest += 10));
+assert.equal(getSecondsAddedByImages(4), (totalForTest += 9));
+assert.equal(getSecondsAddedByImages(5), (totalForTest += 8));
+assert.equal(getSecondsAddedByImages(6), (totalForTest += 7));
+assert.equal(getSecondsAddedByImages(7), (totalForTest += 6));
+assert.equal(getSecondsAddedByImages(8), (totalForTest += 5));
+assert.equal(getSecondsAddedByImages(9), (totalForTest += 4));
+assert.equal(getSecondsAddedByImages(10), (totalForTest += 3));
+assert.equal(getSecondsAddedByImages(11), (totalForTest += 3));
+assert.equal(getSecondsAddedByImages(12), (totalForTest += 3));
+assert.equal(getSecondsAddedByImages(13), (totalForTest += 3));
+assert.equal(getSecondsAddedByImages(14), (totalForTest += 3));
+
+export function remarkReadingTime() {
+  return (tree, { data }) => {
+    let nbOfImages = 0;
+    const filteredTree = filter(tree, (node) => {
+      if (node.type === "image") {
+        nbOfImages++;
+      }
+      return (
+        node.type !== "code" && // Remove code blocks (easily read)
+        node.type !== "mdxJsxFlowElement" && // Remove component rendered (like <Hello />)
+        node.type !== "mdxjsEsm" // Remove imports
+      );
+    });
+
+    const textOnPage = toString(filteredTree);
+
+    // According to Medium.com, the default reading speed is 265WPM (500CPM for CJK, but not needed here)
+    // And the 1st image takes 12s to read, then the 2nd 11s, ... and after 10th image, always 3s
+    // Sources:
+    // - https://help.medium.com/hc/en-us/articles/214991667-Read-time (for 265WPM)
+    // - https://mediumcourse.com/how-is-medium-article-read-time-calculated/ (for the image timing)
+
+    const readingTime = getReadingTime(textOnPage);
+
+    // `readingTime` contains a few information:
+    // - `text`: Human readable duration, like "3 min read",
+    // - `words`: The total word count
+    // - `minutes`: Total reading time duration in minutes
+    // - `time`: Total reading time duration in milliseconds
+    // As we want to manipulate this data manually, we'll just use `words`
+
+    const words = readingTime.words;
+
+    let time = Math.round((words / WORDS_PER_MINUTE) * 60_000); // round to avoid issues with floats
+
+    const nbOfImagesBellow10 = Math.min(nbOfImages, 10);
+    const timeAddedByImages = getSecondsAddedByImages(nbOfImages) * 1000; // to milliseconds
+    time += timeAddedByImages;
+
+    const minutes = time / 60_000;
+    const displayedText = Math.ceil(minutes.toFixed(2));
+
+    const finalReadingTime = {
+      words,
+      time,
+      minutes,
+      displayedText,
+    };
+
+    data.astro.frontmatter.readingTime = readingTime;
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7780,6 +7780,7 @@ __metadata:
     konva: "npm:^9.3.20"
     lit: "npm:^3.2.1"
     manatea: "npm:^0.6.1"
+    mdast-util-to-string: "npm:^4.0.0"
     prettier: "npm:^3.5.3"
     prettier-plugin-astro: "npm:^0.14.1"
     react: "npm:^19.1.0"
@@ -7791,6 +7792,7 @@ __metadata:
     remark-breaks: "npm:^4.0.0"
     reveal.js: "npm:^5.2.1"
     typescript: "npm:^5.8.2"
+    unist-util-filter: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 
@@ -9390,6 +9392,17 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/d324c5a44887bd7e105ce800fcf7533d43f29c48757ac410afd42975de82cc38ea2035c0483f4de82d186691bf3208ef35c644f73aa2b1b20b8e651be5afd293
+  languageName: node
+  linkType: hard
+
+"unist-util-filter@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "unist-util-filter@npm:5.0.1"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10c0/57e523811d4c01c41fc4338a220ee28d27eee2d824ef9230963d5541f30b883a5a5a1623a9dfc4327196cf6253c5f74b3cff361d2531d8e9386f00d549994436
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pb: our current `readingTime` implementation was checking similarly text, and code block. But code blocks aren't really read. And it was also checking JSX node, like `<Hello />` and imports. But those are not even rendered

Finally, I increased the WPM from 200 to 265, and included in the reading time images (to follow Medium implementation)

Before | After
-|-
<img width="781" alt="image" src="https://github.com/user-attachments/assets/e5c8e683-bbc1-4a0f-95a3-aaf2dd6e3801" /> | <img width="781" alt="image" src="https://github.com/user-attachments/assets/5b4337b1-f023-4d83-9f79-7147116f0a18" />
<img width="786" alt="image" src="https://github.com/user-attachments/assets/26a89d1e-2d2b-4bf2-b730-2ded456ca5c6" /> | <img width="771" alt="image" src="https://github.com/user-attachments/assets/c991656a-9dda-4b9e-a081-9b4cbde4fa2a" />
<img width="746" alt="image" src="https://github.com/user-attachments/assets/4f72bfcd-7bda-41a7-9f06-2db93239f85f" /> | <img width="739" alt="image" src="https://github.com/user-attachments/assets/811c76e4-9e63-4d44-8a6e-25a478db9990" />
<img width="502" alt="image" src="https://github.com/user-attachments/assets/b76aff73-1bb2-4289-b097-457bc817c888" /> | <img width="497" alt="image" src="https://github.com/user-attachments/assets/97d98a39-b002-4ecf-926d-e7de9efceee0" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/04992f14-7633-488f-b11a-a8d2913dfb75" /> | <img width="598" alt="image" src="https://github.com/user-attachments/assets/492d901a-37af-4095-8772-f4e5695c20c8" />





