### PR TITLE
reading-time: treat code blocks as images

### DIFF
--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -39,11 +39,11 @@ export function remarkReadingTime() {
   return (tree, { data }) => {
     let nbOfImages = 0;
     const filteredTree = filter(tree, (node) => {
-      if (node.type === "image") {
+      // Treat images & code as "images"
+      if (node.type === "image" || node.type === "code") {
         nbOfImages++;
       }
       return (
-        // Food for thoughts: treat `code` as images 🤔
         node.type !== "code" && // Remove code blocks (easily read)
         node.type !== "mdxJsxFlowElement" && // Remove component rendered (like <Hello />)
         node.type !== "mdxjsEsm" // Remove imports

--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -6,6 +6,10 @@ import assert from "node:assert/strict";
 
 const WORDS_PER_MINUTE = 265;
 
+// Food for thoughts: have 2 different metrics for images & code blocks.
+// And use the image size as a baseline (bigger images will take more time than smaller ones),
+// and same for code blocks: larger code blocks should take more time.
+// But keep the idea of desensitization after a few
 const getSecondsAddedByImages = (imageCount) => {
   const nbOfImagesBellow10 = Math.max(Math.min(imageCount, 10), 0);
   const secondsAddedByImagesBellow10 =

--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -43,7 +43,7 @@ export function remarkReadingTime() {
   return (tree, { data }) => {
     let nbOfImages = 0;
     const filteredTree = filter(tree, (node) => {
-      // Treat images & code as "images"
+      // Treat images & code as "meta content"
       if (node.type === "image" || node.type === "code") {
         nbOfImages++;
       }


### PR DESCRIPTION
Code blocks right now are just escaped. But they are read by the end users. So we should instead treat them as meta content, like images. Actually it makes even more sense to treat them as images than initially thought: no one is reading the whole code in snippets. It's more about the overall feeling / structure of the code. And the more code you see, the more you'll skip, just like images

Before | After
-|-
<img width="599" alt="image" src="https://github.com/user-attachments/assets/ca68b304-c76d-47da-ab75-5db5abf9115f" /> | <img width="587" alt="image" src="https://github.com/user-attachments/assets/90f1d1aa-6f06-43b1-b9f6-bcf26b224c71" />

