### PR TITLE
reading-time: get rid of library, and use Intl instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mdast-util-to-string": "^4.0.0",
     "prettier": "^3.5.3",
     "prettier-plugin-astro": "^0.14.1",
-    "reading-time": "^1.5.0",
     "remark-breaks": "^4.0.0",
     "typescript": "^5.8.2",
     "unist-util-filter": "^5.0.1"

--- a/tools/remark-reading-time.mjs
+++ b/tools/remark-reading-time.mjs
@@ -76,7 +76,7 @@ export function remarkReadingTime() {
     totalMs += timeAddedByImages;
 
     const minutes = totalMs / 60_000;
-    const displayedText = Math.ceil(minutes.toFixed(2)) + " min read";
+    const displayedText = Math.ceil(minutes) + " min read";
 
     const finalReadingTime = {
       words: wordsCount, // The total word count

--- a/yarn.lock
+++ b/yarn.lock
@@ -7788,7 +7788,6 @@ __metadata:
     react-dom: "npm:^19.1.0"
     react-dom-18: "patch:react-dom@npm%3A18.3.1#~/.yarn/patches/react-dom-npm-18.3.1-a805663f38.patch"
     react-konva: "npm:^19.0.3"
-    reading-time: "npm:^1.5.0"
     remark-breaks: "npm:^4.0.0"
     reveal.js: "npm:^5.2.1"
     typescript: "npm:^5.8.2"
@@ -8046,13 +8045,6 @@ __metadata:
   version: 4.1.2
   resolution: "readdirp@npm:4.1.2"
   checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
-  languageName: node
-  linkType: hard
-
-"reading-time@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "reading-time@npm:1.5.0"
-  checksum: 10c0/0f730852fd4fb99e5f78c5b0cf36ab8c3fa15db96f87d9563843f6fd07a47864273ade539ebb184b785b728cde81a70283aa2d9b80cba5ca03b81868be03cabc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow https://github.com/ngryman/reading-time/pull/54#issuecomment-2062995774

As most of the computation is already custom, we were only using the `reading-time` library as a text parser. But `Intl.Segmenter` can do it for us, so…