### PR TITLE
Ayc0/robots.txt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
 
     // Starlight comes with its own sitemap, but it makes all private pages public (and in general all pages public)
     sitemap({
+      filenameBase: "ayc0-sitemap",
       lastmod: new Date("2025-08-21"), // Update every time we want to website to be re-crawled
       filter: (page) => {
         // No slides should be exposed

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://ayc0.github.io/ayc0-sitemap-index.xml


### PR DESCRIPTION
- Google now requires robots.txt for AI agents need agents
- Google stopped indexing the old sitemap for some reason