### PR TITLE
[sequoia] update dark mode colors

### DIFF
--- a/src/components/starlight/PageFrame.astro
+++ b/src/components/starlight/PageFrame.astro
@@ -60,8 +60,19 @@ Astro.locals.starlightRoute.hasSidebar = false;
   }
 
   :root {
-    --sequoia-border-color: var(--sl-color-hairline);
+    /* See https://sequoia.pub/comments#styling */
+
+    /* Text colors */
+    --sequoia-fg-color: var(--sl-color-text);
+    --sequoia-secondary-color: var(--sl-color-gray-3);
     --sequoia-accent-color: var(--sl-color-accent);
+
+    /* Background */
+    --sequoia-bg-color: var(--sl-color-bg);
+
+    /* Borders */
+    --sequoia-border-color: var(--sl-color-hairline);
+    --sequoia-border-radius: 8px;
   }
 </style>
 


### PR DESCRIPTION
Before | After
-|-
<img width="783" height="330" alt="image" src="https://github.com/user-attachments/assets/5155d3f4-2912-4acb-b83d-9aeede802cb7" /> | <img width="817" height="291" alt="image" src="https://github.com/user-attachments/assets/0d036a82-f670-40fd-980b-e04c022bc820" />
<img width="637" height="106" alt="image" src="https://github.com/user-attachments/assets/8a5563c7-9d67-42fd-aa76-497687e04a73" /> | <img width="667" height="101" alt="image" src="https://github.com/user-attachments/assets/2b43138d-a4b1-4842-abe1-03c4ad475ed0" />

