### PR TITLE
fix jump in size of object

### DIFF
--- a/src/components/LinkToPost.astro
+++ b/src/components/LinkToPost.astro
@@ -83,7 +83,8 @@ if (includeSeries) {
   const seriesHtml = getSeriesHtml(post);
   if (seriesHtml) {
     // <object> is here because these are nested links, and browsers don't like that
-    props.title += ` <object type="nested/link">${seriesHtml}</object>`;
+    // Add `style="contain: strict"` otherwise the `<object>` will take a lot of vertical space during initial load, which causes layout shift. `contain: strict` still creates layout shift, but from nothing to something, which is more okay
+    props.title += ` <object type="nested/link" style="contain: strict">${seriesHtml}</object>`;
   }
 }
 ---


### PR DESCRIPTION
Avoid this layout shift:

https://github.com/user-attachments/assets/4a083b3e-7153-4713-998c-66a1733a8eef






Before | After
-|-
<img width="727" height="370" alt="image" src="https://github.com/user-attachments/assets/1158785a-8d8c-4ac4-8eeb-b50da99d9158" /> | <img width="804" height="772" alt="image" src="https://github.com/user-attachments/assets/ff610e18-e001-4a73-b5ca-9e2f949263a1" />
<video src="https://github.com/user-attachments/assets/f68d33e8-7082-450b-bbd4-68a1fce9d008"> | <video src="https://github.com/user-attachments/assets/870f9ab7-30e5-4f30-8ef1-505377020d9d">
