### PR TITLE
fix navigation to RUM

### DIFF
--- a/src/components/Analytics/datadog.ts
+++ b/src/components/Analytics/datadog.ts
@@ -35,7 +35,7 @@ datadogRum.init({
 // See https://docs.astro.build/en/reference/modules/astro-transitions/#astropage-load-event
 document.addEventListener("astro:page-load", () => {
   datadogRum.startView(document.location.pathname);
-})
+});
 
 datadogLogs.init({
   clientToken: DATADOG_CLIENT_TOKEN,

--- a/src/components/Analytics/datadog.ts
+++ b/src/components/Analytics/datadog.ts
@@ -28,7 +28,14 @@ datadogRum.init({
 });
 
 // There is a "bug" in RUM where RUM replaces all URLs that _look like_ a variable with a `?`. Which means that we can't use numbers in URLs. But we do for a few blog posts. So no need for that
-datadogRum.startView(document.location.pathname);
+
+// As we use view transition, we need to use `astro:page-load` to start views for RUM instead of top level for:
+// - initial load (to avoid double counting),
+// - for navigation (as they act as SPA)
+// See https://docs.astro.build/en/reference/modules/astro-transitions/#astropage-load-event
+document.addEventListener("astro:page-load", () => {
+  datadogRum.startView(document.location.pathname);
+})
 
 datadogLogs.init({
   clientToken: DATADOG_CLIENT_TOKEN,


### PR DESCRIPTION
Since https://github.com/Ayc0/ayc0.github.io/pull/266, we lost data in RUM as only initial loads are logged

See the new events in RUM:

<img width="731" height="373" alt="image" src="https://github.com/user-attachments/assets/e1415272-4bc6-43c7-be7d-ebddff5b1796" />


