### PR TITLE
Native transitions

### DIFF
--- a/src/components/Analytics/datadog.ts
+++ b/src/components/Analytics/datadog.ts
@@ -28,14 +28,7 @@ datadogRum.init({
 });
 
 // There is a "bug" in RUM where RUM replaces all URLs that _look like_ a variable with a `?`. Which means that we can't use numbers in URLs. But we do for a few blog posts. So no need for that
-
-// As we use view transition, we need to use `astro:page-load` to start views for RUM instead of top level for:
-// - initial load (to avoid double counting),
-// - for navigation (as they act as SPA)
-// See https://docs.astro.build/en/reference/modules/astro-transitions/#astropage-load-event
-document.addEventListener("astro:page-load", () => {
-  datadogRum.startView(document.location.pathname);
-});
+datadogRum.startView(document.location.pathname);
 
 datadogLogs.init({
   clientToken: DATADOG_CLIENT_TOKEN,

--- a/src/components/SectionsOfPosts.astro
+++ b/src/components/SectionsOfPosts.astro
@@ -1,7 +1,7 @@
 ---
-import type { Post } from "./get-posts";
+import type { Post } from "./posts/get-posts";
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 import { LinkButton } from "@astrojs/starlight/components";
 
 export interface Props {

--- a/src/components/posts/DraftPosts.astro
+++ b/src/components/posts/DraftPosts.astro
@@ -3,6 +3,8 @@ import LinkToPost from "./LinkToPost.astro";
 import { getDraftPosts } from "./get-posts";
 ---
 
-{(await getDraftPosts()).map((post) => (
-  <LinkToPost slug={post.id} includeDate includeTags />
-))}
+{
+  (await getDraftPosts()).map((post) => (
+    <LinkToPost slug={post.id} includeDate includeTags />
+  ))
+}

--- a/src/components/posts/DraftPosts.astro
+++ b/src/components/posts/DraftPosts.astro
@@ -1,0 +1,8 @@
+---
+import LinkToPost from "./LinkToPost.astro";
+import { getDraftPosts } from "./get-posts";
+---
+
+{(await getDraftPosts()).map((post) => (
+  <LinkToPost slug={post.id} includeDate includeTags />
+))}

--- a/src/components/posts/FullListOfPosts.astro
+++ b/src/components/posts/FullListOfPosts.astro
@@ -3,15 +3,17 @@ import LinkToPost from "@components/posts/LinkToPost.astro";
 import { getPublishablePostsByYear } from "@components/posts/get-posts";
 ---
 
-{Object.entries(await getPublishablePostsByYear())
-  .reverse()
-  .map(([year, posts]) => {
-    return (
-      <>
-        <h2 id={year}>{year}</h2>
-        {posts.map((post) => (
-          <LinkToPost slug={post.id} includeDate includeTags />
-        ))}
-      </>
-    );
-  })}
+{
+  Object.entries(await getPublishablePostsByYear())
+    .reverse()
+    .map(([year, posts]) => {
+      return (
+        <>
+          <h2 id={year}>{year}</h2>
+          {posts.map((post) => (
+            <LinkToPost slug={post.id} includeDate includeTags />
+          ))}
+        </>
+      );
+    })
+}

--- a/src/components/posts/FullListOfPosts.astro
+++ b/src/components/posts/FullListOfPosts.astro
@@ -1,0 +1,17 @@
+---
+import LinkToPost from "@components/posts/LinkToPost.astro";
+import { getPublishablePostsByYear } from "@components/posts/get-posts";
+---
+
+{Object.entries(await getPublishablePostsByYear())
+  .reverse()
+  .map(([year, posts]) => {
+    return (
+      <>
+        <h2 id={year}>{year}</h2>
+        {posts.map((post) => (
+          <LinkToPost slug={post.id} includeDate includeTags />
+        ))}
+      </>
+    );
+  })}

--- a/src/components/posts/LatestPosts.astro
+++ b/src/components/posts/LatestPosts.astro
@@ -1,0 +1,6 @@
+---
+import LinkToPost from "./LinkToPost.astro";
+import { getPublishablePosts } from "./get-posts";
+---
+
+{(await getPublishablePosts()).slice(0, 10).map((post) => <LinkToPost slug={post.id} includeDate includeTags />)}

--- a/src/components/posts/LatestPosts.astro
+++ b/src/components/posts/LatestPosts.astro
@@ -3,4 +3,8 @@ import LinkToPost from "./LinkToPost.astro";
 import { getPublishablePosts } from "./get-posts";
 ---
 
-{(await getPublishablePosts()).slice(0, 10).map((post) => <LinkToPost slug={post.id} includeDate includeTags />)}
+{
+  (await getPublishablePosts())
+    .slice(0, 10)
+    .map((post) => <LinkToPost slug={post.id} includeDate includeTags />)
+}

--- a/src/components/posts/LinkToPost.astro
+++ b/src/components/posts/LinkToPost.astro
@@ -7,6 +7,7 @@ import {
   getSeriesHtml,
   getTagsHtml,
 } from "@components/posts/get-posts";
+import { getTransitionStyle } from "@components/transitions";
 
 export interface Props {
   slug: string;
@@ -90,5 +91,5 @@ if (includeSeries) {
 ---
 
 <div data-pagefind-ignore>
-  <LinkCard {...props} transition:name={post.data.title} />
+  <LinkCard {...props} {...getTransitionStyle(post.data.title)} />
 </div>

--- a/src/components/posts/LinkToPost.astro
+++ b/src/components/posts/LinkToPost.astro
@@ -6,7 +6,7 @@ import {
   getCreatedDate,
   getSeriesHtml,
   getTagsHtml,
-} from "@components/get-posts";
+} from "@components/posts/get-posts";
 
 export interface Props {
   slug: string;

--- a/src/components/posts/LinkToPost.astro
+++ b/src/components/posts/LinkToPost.astro
@@ -2,12 +2,12 @@
 import { getEntry, render } from "astro:content";
 import { LinkCard } from "@astrojs/starlight/components";
 
+import { getTransitionName } from "@components/transitions";
 import {
   getCreatedDate,
   getSeriesHtml,
   getTagsHtml,
 } from "@components/posts/get-posts";
-import { getTransitionStyle } from "@components/transitions";
 
 export interface Props {
   slug: string;
@@ -88,8 +88,32 @@ if (includeSeries) {
     props.title += ` <object type="nested/link" style="contain: strict">${seriesHtml}</object>`;
   }
 }
+
+const id = "_" + crypto.randomUUID();
+const transitionName = getTransitionName(post.data.title);
 ---
 
 <div data-pagefind-ignore>
-  <LinkCard {...props} {...getTransitionStyle(post.data.title)} />
+  <LinkCard {...props} id={id} />
 </div>
+
+<script define:vars={{ id, transitionName }}>
+  const element = document.querySelector(`#${id} > .title`);
+
+  if (element) {
+    // You can have the same card rendered multiple times on the page. So only inject the transition name when it is currently visible
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            element.style.viewTransitionName = transitionName;
+          } else {
+            element.style.viewTransitionName = "";
+          }
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(element);
+  }
+</script>

--- a/src/components/posts/get-posts.ts
+++ b/src/components/posts/get-posts.ts
@@ -127,6 +127,7 @@ export const getTagsHtml = ({
   return tags.map((tag) => `<code data-tag=${tag}>#${tag}</code>`).join(" ");
 };
 
+
 export const getSeriesData = ({
   data: { series },
 }: Pick<Post, "data">): { name: string; order: number } | undefined => {

--- a/src/components/posts/get-posts.ts
+++ b/src/components/posts/get-posts.ts
@@ -127,7 +127,6 @@ export const getTagsHtml = ({
   return tags.map((tag) => `<code data-tag=${tag}>#${tag}</code>`).join(" ");
 };
 
-
 export const getSeriesData = ({
   data: { series },
 }: Pick<Post, "data">): { name: string; order: number } | undefined => {

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -50,14 +50,13 @@ let imagePath: string | undefined = await getImagePath(
 }
 
 <style>
-
   @media (prefers-reduced-motion: no-preference) {
     @view-transition {
       navigation: auto;
     }
   }
 
-    @keyframes astroFadeIn {
+  @keyframes astroFadeIn {
     from {
       opacity: 0;
       mix-blend-mode: plus-lighter;
@@ -90,5 +89,4 @@ let imagePath: string | undefined = await getImagePath(
     animation-fill-mode: both;
     animation-name: astroFadeIn;
   }
-
 </style>

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -89,4 +89,8 @@ let imagePath: string | undefined = await getImagePath(
       animation-name: astroFadeIn;
     }
   }
+
+  :global(header) {
+    view-transition-name: header;
+  }
 </style>

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -1,6 +1,5 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro";
-import { ClientRouter } from "astro:transitions";
 
 import { getImagePath } from "@components/images";
 
@@ -21,7 +20,6 @@ let imagePath: string | undefined = await getImagePath(
 );
 ---
 
-<ClientRouter />
 <Default />
 
 {
@@ -50,3 +48,47 @@ let imagePath: string | undefined = await getImagePath(
     />
   ) : null
 }
+
+<style>
+
+  @media (prefers-reduced-motion: no-preference) {
+    @view-transition {
+      navigation: auto;
+    }
+  }
+
+    @keyframes astroFadeIn {
+    from {
+      opacity: 0;
+      mix-blend-mode: plus-lighter;
+    }
+    to {
+      opacity: 1;
+      mix-blend-mode: plus-lighter;
+    }
+  }
+
+  @keyframes astroFadeOut {
+    from {
+      opacity: 1;
+      mix-blend-mode: plus-lighter;
+    }
+    to {
+      opacity: 0;
+      mix-blend-mode: plus-lighter;
+    }
+  }
+  ::view-transition-old(*) {
+    animation-duration: 180ms;
+    animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+    animation-fill-mode: both;
+    animation-name: astroFadeOut;
+  }
+  ::view-transition-new(*) {
+    animation-duration: 180ms;
+    animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+    animation-fill-mode: both;
+    animation-name: astroFadeIn;
+  }
+
+</style>

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -54,39 +54,39 @@ let imagePath: string | undefined = await getImagePath(
     @view-transition {
       navigation: auto;
     }
-  }
 
-  @keyframes astroFadeIn {
-    from {
-      opacity: 0;
-      mix-blend-mode: plus-lighter;
+    @keyframes astroFadeIn {
+      from {
+        opacity: 0;
+        mix-blend-mode: plus-lighter;
+      }
+      to {
+        opacity: 1;
+        mix-blend-mode: plus-lighter;
+      }
     }
-    to {
-      opacity: 1;
-      mix-blend-mode: plus-lighter;
-    }
-  }
 
-  @keyframes astroFadeOut {
-    from {
-      opacity: 1;
-      mix-blend-mode: plus-lighter;
+    @keyframes astroFadeOut {
+      from {
+        opacity: 1;
+        mix-blend-mode: plus-lighter;
+      }
+      to {
+        opacity: 0;
+        mix-blend-mode: plus-lighter;
+      }
     }
-    to {
-      opacity: 0;
-      mix-blend-mode: plus-lighter;
+    ::view-transition-old(*) {
+      animation-duration: 180ms;
+      animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+      animation-fill-mode: both;
+      animation-name: astroFadeOut;
     }
-  }
-  ::view-transition-old(*) {
-    animation-duration: 180ms;
-    animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
-    animation-fill-mode: both;
-    animation-name: astroFadeOut;
-  }
-  ::view-transition-new(*) {
-    animation-duration: 180ms;
-    animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
-    animation-fill-mode: both;
-    animation-name: astroFadeIn;
+    ::view-transition-new(*) {
+      animation-duration: 180ms;
+      animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+      animation-fill-mode: both;
+      animation-name: astroFadeIn;
+    }
   }
 </style>

--- a/src/components/starlight/PageFrame.astro
+++ b/src/components/starlight/PageFrame.astro
@@ -83,6 +83,11 @@ Astro.locals.starlightRoute.hasSidebar = false;
     --sequoia-border-color: var(--sl-color-hairline);
     --sequoia-border-radius: 8px;
   }
+
+  /* Put the Search always at the same place (sometimes set to 0, sometimes unset, and when unset the search goes to the left) */
+  header.header {
+    --__toc-width: 0px;
+  }
 </style>
 
 <Analytics />

--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -8,6 +8,7 @@ import {
   getSeriesHtml,
   getTagsHtml,
 } from "@components/posts/get-posts";
+import { getTransitionStyle } from "@components/transitions";
 
 const post = Astro.locals.starlightRoute.entry;
 
@@ -23,7 +24,7 @@ const series = getSeriesHtml(post);
 ---
 
 <h1 id={PAGE_TITLE_ID}>
-  <span transition:name={post.data.title}>{post.data.title}</span>
+  <span {...getTransitionStyle(post.data.title)}>{post.data.title}</span>
   {
     series || post.data.atUri ? (
       <div class="sub-title">

--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -7,7 +7,7 @@ import {
   getCreatedDate,
   getSeriesHtml,
   getTagsHtml,
-} from "@components/get-posts";
+} from "@components/posts/get-posts";
 
 const post = Astro.locals.starlightRoute.entry;
 

--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -8,7 +8,7 @@ import {
   getSeriesHtml,
   getTagsHtml,
 } from "@components/posts/get-posts";
-import { getTransitionStyle } from "@components/transitions";
+import { getTransitionName } from "@components/transitions";
 
 const post = Astro.locals.starlightRoute.entry;
 
@@ -24,7 +24,9 @@ const series = getSeriesHtml(post);
 ---
 
 <h1 id={PAGE_TITLE_ID}>
-  <span {...getTransitionStyle(post.data.title)}>{post.data.title}</span>
+  <span style={{ viewTransitionName: getTransitionName(post.data.title) }}
+    >{post.data.title}</span
+  >
   {
     series || post.data.atUri ? (
       <div class="sub-title">

--- a/src/components/starlight/Pagination.astro
+++ b/src/components/starlight/Pagination.astro
@@ -4,7 +4,7 @@ import Default from "@astrojs/starlight/components/Pagination.astro";
 import {
   getSeriesData,
   getPublishablePostsMatchingSeries,
-} from "@components/get-posts";
+} from "@components/posts/get-posts";
 
 const thisSeriesData = getSeriesData(Astro.locals.starlightRoute.entry);
 

--- a/src/components/transitions.ts
+++ b/src/components/transitions.ts
@@ -1,4 +1,4 @@
-export const getTransitionName = (name: string) => {
+const getTransitionName = (name: string) => {
   return name.replace(/[^a-zA-Z0-9]+/g, "_");
 };
 

--- a/src/components/transitions.ts
+++ b/src/components/transitions.ts
@@ -1,8 +1,3 @@
-const getTransitionName = (name: string) => {
+export const getTransitionName = (name: string) => {
   return name.replace(/[^a-zA-Z0-9]+/g, "_");
-};
-
-export const getTransitionStyle = (name: string) => {
-  const transitionName = getTransitionName(name);
-  return { style: { viewTransitionName: transitionName } };
 };

--- a/src/components/transitions.ts
+++ b/src/components/transitions.ts
@@ -1,0 +1,8 @@
+export const getTransitionName = (name: string) => {
+  return name.replace(/[^a-zA-Z0-9]+/g, "_");
+};
+
+export const getTransitionStyle = (name: string) => {
+  const transitionName = getTransitionName(name);
+  return { style: { viewTransitionName: transitionName } };
+};

--- a/src/content/docs/posts/blocz-react-responsive-v3-0.mdx
+++ b/src/content/docs/posts/blocz-react-responsive-v3-0.mdx
@@ -9,7 +9,7 @@ image: /src/assets/react-responsive.png
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mnatxgtcbv2o"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 The v3 of `@blocz/react-responsive` was just released with few bug fixes and new names. You can check out the full release details here: https://github.com/bloczjs/react-responsive/releases/tag/v3.0.0
 

--- a/src/content/docs/posts/blocz-react-responsive-v4-0.mdx
+++ b/src/content/docs/posts/blocz-react-responsive-v4-0.mdx
@@ -9,7 +9,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mnatxgk3db
 blueskyPostUri: "https://bsky.app/profile/did:plc:wifmfjqoxnruni5h62e6zp2y/post/3leplbrggy22b"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 `@blocz/react-responsive` v4 was just released with a few removals of deprecated APIs. Those are `<Match>` and the CSS-in-JS support. You can check out the full release details here: https://github.com/bloczjs/react-responsive/releases/tag/v4.0.0
 

--- a/src/content/docs/posts/blocz-react-responsive-v5-0.mdx
+++ b/src/content/docs/posts/blocz-react-responsive-v5-0.mdx
@@ -9,7 +9,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mnasqzmhg5
 blueskyPostUri: "https://bsky.app/profile/did:plc:wifmfjqoxnruni5h62e6zp2y/post/3mnau73adik2x"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 `@blocz/react-responsive` v5.0 was just released. Let’s go through all the different features and changes added by this new major version.
 

--- a/src/content/docs/posts/blocz-react-responsive-v5-1.mdx
+++ b/src/content/docs/posts/blocz-react-responsive-v5-1.mdx
@@ -9,7 +9,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mnmjwswjzm
 blueskyPostUri: "https://bsky.app/profile/did:plc:wifmfjqoxnruni5h62e6zp2y/post/3mnmpijgijc2q"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 As mentioned in the previous post, going forward `@blocz/react-responsive` will follow strict semver with new features released in minor versions & deprecations. And major will only be about removals of deprecated features (no added features).
 

--- a/src/content/docs/posts/drafts.mdx
+++ b/src/content/docs/posts/drafts.mdx
@@ -7,7 +7,6 @@ pagefind: false
 
 import DraftPosts from "@components/posts/DraftPosts.astro";
 
-
 List of all posts that are in the process, but not ready to be open to public:
 
 <DraftPosts />

--- a/src/content/docs/posts/drafts.mdx
+++ b/src/content/docs/posts/drafts.mdx
@@ -5,12 +5,9 @@ hiddenFromSequoia: true
 pagefind: false
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
-import { getDraftPosts } from "@components/get-posts";
+import DraftPosts from "@components/posts/DraftPosts.astro";
+
 
 List of all posts that are in the process, but not ready to be open to public:
 
-<></>
-{(await getDraftPosts()).map((post) => (
-  <LinkToPost slug={post.id} includeDate includeTags />
-))}
+<DraftPosts />

--- a/src/content/docs/posts/full.mdx
+++ b/src/content/docs/posts/full.mdx
@@ -4,19 +4,6 @@ template: splash
 hiddenFromSequoia: true
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
-import { getPublishablePostsByYear } from "@components/get-posts";
+import FullListOfPosts from "@components/posts/FullListOfPosts.astro";
 
-<></>
-{Object.entries(await getPublishablePostsByYear())
-  .reverse()
-  .map(([year, posts]) => {
-    return (
-      <>
-        <h2 id={year}>{year}</h2>
-        {posts.map((post) => (
-          <LinkToPost slug={post.id} includeDate includeTags />
-        ))}
-      </>
-    );
-  })}
+<FullListOfPosts />

--- a/src/content/docs/posts/how-to-bump-the-specificity.mdx
+++ b/src/content/docs/posts/how-to-bump-the-specificity.mdx
@@ -7,7 +7,7 @@ wip: true
 hiddenFromSequoia: true
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 :::caution[Warning]
 Still in draft

--- a/src/content/docs/posts/index.mdx
+++ b/src/content/docs/posts/index.mdx
@@ -4,12 +4,11 @@ template: splash
 hiddenFromSequoia: true
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
-import { getPublishablePosts } from "@components/get-posts";
+import LatestPosts from "@components/posts/LatestPosts.astro";
 
 ### Latest posts
 
-{(await getPublishablePosts()).slice(0, 10).map((post) => <LinkToPost slug={post.id} includeDate includeTags />)}
+<LatestPosts />
 
 ### See more
 

--- a/src/content/docs/posts/light-dark-mode-corrections.mdx
+++ b/src/content/docs/posts/light-dark-mode-corrections.mdx
@@ -8,7 +8,7 @@ description: "In my previous articles about Light/dark mode, I made a few mistak
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw3i5st2i"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 In this post, I want to fix some mistakes I made in other posts, and also include new elements I discovered on this topic since I wrote them.
 

--- a/src/content/docs/posts/light-dark-mode-system-mode-user-preferences.mdx
+++ b/src/content/docs/posts/light-dark-mode-system-mode-user-preferences.mdx
@@ -9,7 +9,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw4tg4m
 ---
 
 import Codepen from "@components/Codepen.astro";
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 In the previous posts, we saw:
 

--- a/src/content/docs/posts/light-dark-mode-the-simple-way.mdx
+++ b/src/content/docs/posts/light-dark-mode-the-simple-way.mdx
@@ -9,7 +9,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw4zx3v
 ---
 
 import Codepen from "@components/Codepen.astro";
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 In the previous post, we've seen how to use the `color-scheme` html meta tag to benefit from the browser default themes.
 

--- a/src/content/docs/posts/light-dark-mode-user-input.mdx
+++ b/src/content/docs/posts/light-dark-mode-user-input.mdx
@@ -11,7 +11,7 @@ atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw4wnzy
 ---
 
 import Codepen from "@components/Codepen.astro";
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 In the previous post, we saw how to use CSS variables to adapt the display to user system preferences.
 

--- a/src/content/docs/posts/migrating-class-components-to-hooks-rules.mdx
+++ b/src/content/docs/posts/migrating-class-components-to-hooks-rules.mdx
@@ -7,7 +7,7 @@ description: "Migrating class components to hooks can be difficult. There is no 
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw5gmtl2i"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 When transitioning from classes to hooks, there are a few rules:
 

--- a/src/content/docs/posts/responsive-design-in-react.mdx
+++ b/src/content/docs/posts/responsive-design-in-react.mdx
@@ -7,7 +7,7 @@ description: "This short article focuses on when to use raw CSS vs React binding
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dw5a7ln2w"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 Hi, I'm Ayc0, maintainer of the library [`@blocz/react-responsive`](https://www.npmjs.com/package/@blocz/react-responsive) that aims to provide easy utils in React to handle Responsive design.
 

--- a/src/content/docs/posts/series.mdx
+++ b/src/content/docs/posts/series.mdx
@@ -7,7 +7,7 @@ pagefind: false
 ---
 
 import SectionsOfPosts from "@components/SectionsOfPosts.astro";
-import { getPublishablePostsMatchingSeries } from "@components/get-posts";
+import { getPublishablePostsMatchingSeries } from "@components/posts/get-posts";
 import { series as seriesList } from "../../../content.config";
 
 <SectionsOfPosts

--- a/src/content/docs/posts/tags.mdx
+++ b/src/content/docs/posts/tags.mdx
@@ -6,7 +6,7 @@ pagefind: false
 ---
 
 import SectionsOfPosts from "@components/SectionsOfPosts.astro";
-import { getPostsByTags } from "@components/get-posts";
+import { getPostsByTags } from "@components/posts/get-posts";
 
 <SectionsOfPosts
   sections={Object.entries(await getPostsByTags())}

--- a/src/content/docs/posts/yarn-lock-how-to-read-it.mdx
+++ b/src/content/docs/posts/yarn-lock-how-to-read-it.mdx
@@ -8,7 +8,7 @@ description: "Yarn comes with a lock file `yarn.lock` that isn’t made for huma
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dvsulxu2i"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 ## Introduction
 

--- a/src/content/docs/posts/yarn-lock-how-to-update-it.mdx
+++ b/src/content/docs/posts/yarn-lock-how-to-update-it.mdx
@@ -8,7 +8,7 @@ description: "Yarn comes with a lock file `yarn.lock` that isn’t made for huma
 atUri: "at://did:plc:wifmfjqoxnruni5h62e6zp2y/site.standard.document/3mn6dvrzxtq2c"
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 ## Introduction
 

--- a/src/content/docs/posts/yarn-the-good-parts.mdx
+++ b/src/content/docs/posts/yarn-the-good-parts.mdx
@@ -10,7 +10,7 @@ wip: true
 hiddenFromSequoia: true
 ---
 
-import LinkToPost from "@components/LinkToPost.astro";
+import LinkToPost from "@components/posts/LinkToPost.astro";
 
 :::caution[Warning]
 Still in draft

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 
 import rss from "@astrojs/rss";
 
-import { getPublishablePosts } from "@components/get-posts";
+import { getPublishablePosts } from "@components/posts/get-posts";
 import { getImagePath } from "@components/images";
 
 export const GET: APIRoute = async (context) => {


### PR DESCRIPTION
## Motivation

Weirdly, there is a bug in PROD builds (not in dev builds) where some animations are botched. I failed to manually investigate it, but here is claude investigation:

```
Root cause: Astro's transition:name directive pushes view-transition-name CSS
into <head> via result._metadata.extraHead at render time. For pages without an
OG image (posts/index.mdx, posts/full.mdx, posts/series.mdx, posts/tags.mdx),
Head.astro's getImagePath(undefined) resolves in a single microtask
(Promise.resolve(undefined)) — before the async card components (LatestPosts →
LinkToPost) finish rendering. This causes renderAllHeadContent() to run first,
setting hasRenderedHead = true, so all subsequent renderTransition() calls for
cards are discarded.

Blog post pages with images work because loading the image asset takes multiple
async ticks, giving body content time to call renderTransition first.

Fix: In LinkToPost.astro, replaced transition:name={post.data.title} on <LinkCard>
with style={view-transition-name: ${viewTransitionName(post.data.title)}} on the
outer <div>. Added viewTransitionName() to get-posts.ts that replicates Astro's
reEncode() + cssesc() encoding. Inline styles bypass the head injection mechanism
entirely — the browser matches transition partners by the view-transition-name CSS
property value, not by how/where the CSS is declared.
```

So inject of trying to fix it (seems to be deep in Astro), I decided to revert https://github.com/Ayc0/ayc0.github.io/pull/266. This PR already broke RUM tracking (see https://github.com/Ayc0/ayc0.github.io/pull/283), and I also reverted this fix as no longer needed.

https://github.com/Ayc0/ayc0.github.io/pull/280 can't work anymore, so I also reverted it partially, instead we have custom CSS for the view transition names. And the rest is pure CSS

## Changes

- revert https://github.com/Ayc0/ayc0.github.io/pull/266 & https://github.com/Ayc0/ayc0.github.io/pull/283 & https://github.com/Ayc0/ayc0.github.io/pull/280
- re-implement https://github.com/Ayc0/ayc0.github.io/pull/280 using a custom `getTransitionStyle`,
- create pure CSS for view transition in the `Head.astro`
- i also moved all the posts related helpers in a `posts/` folder, and I created new components for all the MDX listings (2 reasons: 1. I thought it was a bug with MDX, 2. the mdx formatter is buggy and I had to rely on `<></>` just before it to force the JSX context. This is now gone)

## QA

You can see that when going from the list to 1 post, the header doesn't move. But when going from a post to a post, it does. 

With pure CSS, it now always works:

Before | After
-|-
<video src="https://github.com/user-attachments/assets/dd1b7321-7bc1-4439-80f1-e41aed8aca18"> | <video src="https://github.com/user-attachments/assets/ddb3f085-cc26-4769-9989-1efc17fd9836">







