### PR TITLE
fix GITHUB_RUN_ID

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import react from "@astrojs/react";
 
 import starlight from "@astrojs/starlight";
@@ -17,6 +17,16 @@ export default defineConfig({
   vite: {
     build: {
       sourcemap: true,
+    },
+  },
+
+  env: {
+    schema: {
+      GITHUB_RUN_ID: envField.string({
+        context: "client",
+        access: "public",
+        default: "local",
+      }),
     },
   },
 

--- a/src/components/Analytics/datadog.ts
+++ b/src/components/Analytics/datadog.ts
@@ -1,3 +1,5 @@
+import { GITHUB_RUN_ID } from "astro:env/client";
+
 import { datadogRum } from "@datadog/browser-rum";
 import { datadogLogs } from "@datadog/browser-logs";
 
@@ -6,7 +8,7 @@ import { datadogLogs } from "@datadog/browser-logs";
 // - RUM & Logs can be bundled together (as they share the same dependencies)
 
 const MODE = import.meta.env.MODE;
-const VERSION = `${new Date().toISOString().split("T")[0]}--${import.meta.env.GITHUB_RUN_ID || "local"}`;
+const VERSION = `${new Date().toISOString().split("T")[0]}--${GITHUB_RUN_ID}`;
 const DATADOG_CLIENT_TOKEN = "pub65a306a096de7824a32d9879df04de68";
 const DATADOG_RUM_APPLICATION_ID = "d5dc836c-8af7-48c6-85d4-ada010f382f5";
 


### PR DESCRIPTION
Since https://github.com/Ayc0/ayc0.github.io/pull/282, I lost all version trafic in DD: all versions are reported as `<>--local`

<img width="1275" height="530" alt="image" src="https://github.com/user-attachments/assets/fcf0804a-f1a6-41db-a6a2-fdccab9a84f9" />


And no other versions at all:

<img width="1297" height="542" alt="image" src="https://github.com/user-attachments/assets/62218d40-e908-40ad-8da0-b6236e396ebe" />
